### PR TITLE
improved performance of viewing and selection for large files

### DIFF
--- a/geom/dPoly.cpp
+++ b/geom/dPoly.cpp
@@ -62,6 +62,22 @@ void dPoly::reset() {
   clearExtraData();
 }
 
+void dPoly::annoBdBox(double & xll, double & yll, double & xur, double & yur) const {
+
+	xll = yll = DBL_MAX/4.0;
+	xur = yur = -DBL_MAX/4.0; // Use 1/4.0 to avoid overflow when ...
+	// ... finding width and height
+
+	for (int s = 0; s < (int)m_annotations.size(); s++) {
+		const anno & A = m_annotations[s];
+		xll = min(xll, A.x);
+		xur = max(xur, A.x);
+		yll = min(yll, A.y);
+		yur = max(yur, A.y);
+	}
+
+}
+
 void dPoly::bdBox(double & xll, double & yll, double & xur, double & yur) const {
 
   // The bounding box of all polygons

--- a/geom/dPoly.cpp
+++ b/geom/dPoly.cpp
@@ -1650,7 +1650,6 @@ void dPoly::markPolysIntersectingBox(// Inputs
 			}
 		}
 
-		mark[box.id] = 1;
 	}
 
 	return;

--- a/geom/dPoly.cpp
+++ b/geom/dPoly.cpp
@@ -246,7 +246,8 @@ void dPoly::set_annoByType(const std::vector<anno> & annotations, AnnoType annoT
 void dPoly::clipPoly(// inputs
                      double clip_xll, double clip_yll,
                      double clip_xur, double clip_yur,
-                     dPoly & clippedPoly) { // output
+                     dPoly & clippedPoly, // output
+					 const std::map<int, int> *selected ) {
 
   assert(this != &clippedPoly); // source and destination must be different
 
@@ -275,6 +276,8 @@ void dPoly::clipPoly(// inputs
 
   for (auto &box : boxes) {
 	  int pIter = box.id;
+	  if (selected && selected->find(pIter) == selected->end()) continue;
+
 	  int start = starting_ids[pIter];
 
 	  int  isClosed = isPolyClosed [pIter];
@@ -1432,7 +1435,7 @@ const boxTree< dRectWithId> * dPoly::getBoundingBoxTree() const{
 	// We check the size too as an extra caution to make sure tree size matches polygons size.
 	// Size check is not needed ideally.
 	if (!m_boundingBoxTree || m_boundingBoxTree->size() != m_numVerts.size()){
-		//cout <<"DEBUG building tree "<< m_numVerts.size()<< endl;
+
 		if (m_boundingBoxTree) delete m_boundingBoxTree;
 		m_boundingBoxTree = new boxTree< dRectWithId>();
 
@@ -1443,8 +1446,6 @@ const boxTree< dRectWithId> * dPoly::getBoundingBoxTree() const{
 			rects.push_back(dRectWithId(xll[i],  yll[i], xur[i], yur[i], i));
 		}
 		m_boundingBoxTree->formTreeOfBoxes(rects);
-	} else {
-		//cout <<"DEBUG TREE exists"<<endl;
 	}
 	return m_boundingBoxTree;
 }

--- a/geom/dPoly.h
+++ b/geom/dPoly.h
@@ -249,7 +249,11 @@ public:
   void * img;
   
 private:
-  const boxTree< dRectWithId> & getBoundingBoxTree() const;
+  // This will create the bounding box tree and return a pointer to it
+  // If three is already created it will just return the pointer
+  const boxTree< dRectWithId> * getBoundingBoxTree() const;
+
+  // Clear pre-computed data if geometry changes
   void clearExtraData();
 
   bool getColorInCntFile(const std::string & line, std::string & color);
@@ -272,7 +276,9 @@ private:
   std::vector<anno>        m_polyIndexAnno; // Anno showing poly index in a set of polys
   std::vector<anno>        m_layerAnno;     // Anno showing layer number
 
-  mutable boxTree< dRectWithId> m_boundingBoxTree;
+  // The following items are used for performance.
+  // They should be cleared if geometry changes by calling clearExtraData()
+  mutable boxTree< dRectWithId> *m_boundingBoxTree = nullptr;
   mutable std::vector<int>  m_startingIndices;
 
 };

--- a/geom/dPoly.h
+++ b/geom/dPoly.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <baseUtils.h>
 #include <geomUtils.h>
+#include "dTree.h"
 
 namespace utils {
   
@@ -248,11 +249,13 @@ public:
   void * img;
   
 private:
+  const boxTree< dRectWithId> & getBoundingBoxTree() const;
+  void clearExtraData();
 
   bool getColorInCntFile(const std::string & line, std::string & color);
   void get_annoByType(std::vector<anno> & annotations, AnnoType annoType);
   void set_annoByType(const std::vector<anno> & annotations, AnnoType annoType);
-  std::vector<int> get_startingIndices() const;
+  const std::vector<int> & getStartingIndices() const;
   // If isPointCloud is true, treat each point as a set of unconnected points
   bool                     m_isPointCloud;
 
@@ -268,6 +271,10 @@ private:
   std::vector<anno>        m_vertIndexAnno; // Anno showing vertex index
   std::vector<anno>        m_polyIndexAnno; // Anno showing poly index in a set of polys
   std::vector<anno>        m_layerAnno;     // Anno showing layer number
+
+  mutable boxTree< dRectWithId> m_boundingBoxTree;
+  mutable std::vector<int>  m_startingIndices;
+
 };
 
 } // end namespace utils

--- a/geom/dPoly.h
+++ b/geom/dPoly.h
@@ -170,6 +170,7 @@ public:
   void compLayerAnno();
 
   void bdBox(double & xll, double & yll, double & xur, double & yur) const;
+  void annoBdBox(double & xll, double & yll, double & xur, double & yur) const;
 
   void bdBoxes(std::vector<double> & xll, std::vector<double> & yll,
                std::vector<double> & xur, std::vector<double> & yur) const;

--- a/geom/dPoly.h
+++ b/geom/dPoly.h
@@ -81,7 +81,8 @@ public:
   void clipPoly(// inputs
                 double clip_xll, double clip_yll,
                 double clip_xur, double clip_yur,
-                dPoly & clippedPoly // output
+                dPoly & clippedPoly, // output
+				const std::map<int, int> *selected = nullptr // optional input, if provided only clip selected polygons
                 );
 
   void shift(double shift_x, double shift_y);

--- a/geom/dTree.h
+++ b/geom/dTree.h
@@ -126,11 +126,13 @@ public:
 
   void getBoxesInRegion(double xl, double yl, double xh, double yh, // Inputs
                         std::vector<Box> & outBoxes                 // Outputs
-                        );
+                        ) const;
 
   boxNode<Box> * getTreeRoot(){
     return m_root;
   }
+  void clear();
+  size_t size() const { return m_nodePool.size();}
 
 private:
 
@@ -144,7 +146,7 @@ private:
                                 double xl, double yl, double xh, double yh,
                                 boxNode<Box> * root,
                                 // Outputs
-                                std::vector<Box> & outBoxes);
+                                std::vector<Box> & outBoxes) const;
 
   void reset();
   boxNode<Box> * getNewboxNode();
@@ -163,6 +165,10 @@ boxTree<Box>::boxTree(){
   return;
 }
 
+template <typename Box>
+void boxTree<Box>::clear(){
+	reset();
+}
 template <typename Box>
 void boxTree<Box>::reset(){
   m_freeNodeIndex = 0;
@@ -275,7 +281,7 @@ void boxTree<Box>::getBoxesInRegion(// Inputs
                                     double xl, double yl, double xh, double yh,
                                     // Output
                                     std::vector<Box> & outBoxes
-                                    ){
+                                    ) const{
 
   outBoxes.clear();
   if (xl > xh || yl > yh || m_root == NULL) return;
@@ -292,7 +298,7 @@ void boxTree<Box>::getBoxesInRegionInternal(// Inputs
                                             boxNode<Box> * root,
                                             // Outputs
                                             std::vector<Box> & outBoxes
-                                            ){
+                                            ) const{
 
   assert (root != NULL);
 

--- a/geom/geomUtils.cpp
+++ b/geom/geomUtils.cpp
@@ -43,16 +43,21 @@
 using namespace std;
 using namespace utils;
 
-
-void utils::Timer::tick(){
+utils::Timer::Timer(const std::string &prefix){
+	m_prefix = prefix;
 	m_start = std::chrono::steady_clock::now();
 }
-void utils::Timer::tock(const std::string &prefix){
+utils::Timer::~Timer(){
+	tock("");
+}
+
+void utils::Timer::tock(const std::string &append){
 	auto time_end = std::chrono::steady_clock::now();
 
 	std::chrono::duration<double> elapsed_seconds = time_end - m_start;
-
-	std::cout <<prefix <<" Time = "<< elapsed_seconds.count()<<  std::endl;
+	std::string msg = m_prefix + " " + append;
+	while(msg.size() < 50) msg +=("-");
+	std::cout <<msg <<" Time = "<< elapsed_seconds.count()<<  std::endl;
 
 	m_start = std::chrono::steady_clock::now();
 }

--- a/geom/geomUtils.cpp
+++ b/geom/geomUtils.cpp
@@ -43,6 +43,20 @@
 using namespace std;
 using namespace utils;
 
+
+void utils::Timer::tick(){
+	m_start = std::chrono::steady_clock::now();
+}
+void utils::Timer::tock(const std::string &prefix){
+	auto time_end = std::chrono::steady_clock::now();
+
+	std::chrono::duration<double> elapsed_seconds = time_end - m_start;
+
+	std::cout <<prefix <<" Time = "<< elapsed_seconds.count()<<  std::endl;
+
+	m_start = std::chrono::steady_clock::now();
+}
+
 std::ostream& operator<<(std::ostream& os, const anno& A){
   os << A.x << ' ' << A.y << ' ' << A.label << std::endl;
   return os;

--- a/geom/geomUtils.cpp
+++ b/geom/geomUtils.cpp
@@ -243,11 +243,6 @@ void utils::searchForColor(std::string lineStr, // input, not a reference on pur
 //      "orange", "yellow", "pink", "cyan", "lightGray",
 //      "darkGray", "fuchsia", "aqua", "navy", "gold"};
 
-  const char * xgraph_colors[] =
-    {"black", "white", "red", "blue", "green", "violet", // 0,  ..., 5
-     "orange", "yellow", "pink", "cyan", "#A2B5CD",      // 6,  ..., 10
-     "#6C7B8B", "#FF00FF", "#00CDCD", "navy", "gold"     // 11, ..., 15
-    };
 
   char       * line  = (char*)lineStr.c_str();
   const char * col   = "color";
@@ -272,6 +267,13 @@ void utils::searchForColor(std::string lineStr, // input, not a reference on pur
 
   color = string(pch);
 
+  const char * xgraph_colors[] =
+    {"black", "white", "red", "blue", "green", "violet", // 0,  ..., 5
+     "orange", "yellow", "pink", "cyan", "#A2B5CD",      // 6,  ..., 10
+     "#6C7B8B", "#FF00FF", "#00CDCD", "navy", "gold"     // 11, ..., 15
+    };
+
+
   int numColors = sizeof(xgraph_colors)/sizeof(char*);
 
   // If the color is given as a number, per xgraph's conventions
@@ -291,13 +293,15 @@ bool utils::searchForAnnotation(std::string lineStr, anno & annotation){
   // Return true on success.
 
   istringstream iss (lineStr);
-  string an, label;
+  string an;
   double x, y;
+  if ( ( !(iss >> an)) || an != "anno") return false;
 
-  if ( ( !(iss >> an >> x >> y) ) || an != "anno" ){
+  if ( !(iss >> x >> y) ){
     return false;
   }
 
+  string label;
   getline(iss, label); // Everything else goes to the label
 
   annotation.x     = x;

--- a/geom/geomUtils.h
+++ b/geom/geomUtils.h
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <set>
 #include <cassert>
+#include <chrono>
 
 struct dPoint{
   double x, y;
@@ -58,6 +59,17 @@ struct anno {
 std::ostream& operator<<(std::ostream& os, const anno& A);
 
 namespace utils{
+
+class Timer {
+public:
+	Timer() = default;
+	void tick();
+	void tock(const std::string &prefix);
+
+private:
+	std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
+
+};
 
   void snapPolyLineTo45DegAngles(bool isClosedPolyLine,
                                  int numVerts, double * xv, double * yv);
@@ -101,6 +113,10 @@ namespace utils{
 
     bool isInSide(double x, double y) const {
     	return (x >= xl && x <= xh && y >= yl && y <= yh);
+    }
+
+    bool contains(const dRect &rec){
+    	return (xl <= rec.xl && xh >= rec.xh && yl <= rec.yl && yh >= rec.yh);
     }
   };
 

--- a/geom/geomUtils.h
+++ b/geom/geomUtils.h
@@ -61,14 +61,21 @@ std::ostream& operator<<(std::ostream& os, const anno& A);
 namespace utils{
 
 class Timer {
+	// A class that prints time in seconds
 public:
-	Timer() = default;
-	void tick();
-	void tock(const std::string &prefix);
+	// Constructor will start the clock, prefix is the string to print before the time
+	Timer(const std::string &prefix);
+
+	// Destructor will print the time accumalated since the last tock or
+	// since the constructor if tock was not called before
+	~Timer();
+
+	// Print the accumulated time and restart the clock, append will be added to prefix when printing the time
+	void tock(const std::string &append);
 
 private:
-	std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
-
+	std::chrono::time_point<std::chrono::steady_clock> m_start;
+	std::string m_prefix;
 };
 
   void snapPolyLineTo45DegAngles(bool isClosedPolyLine,

--- a/geom/polyUtils.cpp
+++ b/geom/polyUtils.cpp
@@ -413,11 +413,17 @@ void utils::bdBox(const std::vector<dPoly> & polyVec,
   double big = DBL_MAX;
   xll = big; yll = big; xur = -big; yur = -big;
   for (int p = 0; p < (int)polyVec.size(); p++) {
-    if (polyVec[p].get_totalNumVerts() == 0) continue;
+
     double xll0, yll0, xur0, yur0;
     polyVec[p].bdBox(xll0, yll0, xur0, yur0);
     xll = min(xll, xll0); xur = max(xur, xur0);
     yll = min(yll, yll0); yur = max(yur, yur0);
+
+    polyVec[p].annoBdBox(xll0, yll0, xur0, yur0);
+
+    xll = min(xll, xll0); xur = max(xur, xur0);
+    yll = min(yll, yll0); yur = max(yur, yur0);
+
   }
 
   return;

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -1198,7 +1198,7 @@ void polyView::translateSelectedPolys(std::vector<double> & shiftVec) {
 
   saveDataForUndo(false);
 
-  std::cout << "Resetting the view after the translation was applied." << std::endl;
+  std::cout << " Resetting the view after the translation was applied." << std::endl;
   resetView();  
   
   return;
@@ -1255,7 +1255,7 @@ void polyView::rotateSelectedPolys(std::vector<double> & angle) {
 
   saveDataForUndo(false);
 
-  std::cout << "Resetting the view after the rotation was applied." << std::endl;
+  std::cout << " Resetting the view after the rotation was applied." << std::endl;
   resetView();  
 
   return;
@@ -1311,7 +1311,7 @@ void polyView::scaleSelectedPolys(std::vector<double> & scale) {
   saveDataForUndo(false);
   refreshPixmap();
 
-  std::cout << "Resetting the view after the scale was applied." << std::endl;
+  std::cout << " Resetting the view after the scale was applied." << std::endl;
   resetView();
   
   return;
@@ -1367,7 +1367,7 @@ void polyView::transformSelectedPolys(std::vector<double> & T) {
 
   saveDataForUndo(false);
 
-  std::cout << "Resetting the view after the transform was applied." << std::endl;
+  std::cout << " Resetting the view after the transform was applied." << std::endl;
   resetView();  
 
   return;
@@ -2099,7 +2099,7 @@ void polyView::printCurrCoords(const Qt::MouseButton & state, // input
 
   }
 
-  cout << "Point" << " ("
+  cout <<setprecision(16)<< " Point" << " ("
        << wx << ", " << wy << ")";
   if (m_prevClickExists) {
     cout  << " dist from prev: ("
@@ -2288,11 +2288,11 @@ void polyView::toggleDifferentColors() {
   m_polyVecBk        = m_polyVec;
   m_polyOptionsVecBk = m_polyOptionsVec;
 
-  cout << "Changing the polygons colors" << endl;
+  cout << " Changing the polygons colors" << endl;
   for (int pIter = 0; pIter < (int)m_polyVec.size(); pIter++) {
     string color = colors[pIter % numColors];
     m_polyVec[pIter].set_color(color);
-    cout << color << "\t" << m_polyOptionsVec[pIter].polyFileName << endl;
+    cout <<" "<< color << "\t" << m_polyOptionsVec[pIter].polyFileName << endl;
   }
 
   refreshPixmap();
@@ -2331,7 +2331,7 @@ void polyView::toggleShowPolyDiff() {
   }
 
   if (m_polyVec.size() > 2) {
-    cout << "Showing the differences of the first two polygon files "
+    cout << " Showing the differences of the first two polygon files "
          << "and ignoring the rest" << endl;
   }
 
@@ -2355,7 +2355,7 @@ void polyView::toggleShowPolyDiff() {
                vP, vQ // outputs
                );
 
-  cout << "Changing the polygons colors to " << color1 << " and "
+  cout << " Changing the polygons colors to " << color1 << " and "
        << color2 << " in show-poly-diff mode." << endl;
 
   P.set_color(color1);
@@ -2427,7 +2427,7 @@ void polyView::plotDiff(int direction) {
   // The segment to plot
   segDist S = m_distVec[m_indexOfDistToPlot];
 
-  cout << "Distance: " << S.dist << endl;
+  cout << " Distance: " << S.dist << endl;
   
   if (S.dist == 0) {
     // Skip 0 diffs, as those are not interesting. First see if there's a non-zero diff.
@@ -2440,7 +2440,7 @@ void polyView::plotDiff(int direction) {
     }
 
     if (has_nonzero_diff) {
-      std::cout << "Skipping vertex at which the polygons are agree fully." << std::endl;
+      std::cout << " Skipping vertex at which the polygons are agree fully." << std::endl;
       plotDiff(direction); // call itself
       return;
     }
@@ -2559,7 +2559,7 @@ void polyView::toggleAlignMode() {
 
     m_totalT.reset();
   }else{
-    cout << "\nCombined transform:" << endl;
+    cout << "\n Combined transform:" << endl;
     m_totalT.print();
     cout << endl;
   }
@@ -2799,7 +2799,7 @@ void polyView::saveMark() {
 
   plotMark(m_menuX, m_menuY);
 
-  cout << "Saving the mark to " << markFile << endl;
+  cout << " Saving the mark to " << markFile << endl;
   ofstream mark(markFile.c_str());
   mark << "color = white" << endl;
   mark << m_menuX << ' ' << m_menuY << endl;
@@ -2959,7 +2959,7 @@ void polyView::restoreDataAtUndoPos() {
 void polyView::undo() {
 
   if (m_posInUndoStack <= 0) {
-    cout << "No actions to undo" << endl;
+    cout << " No actions to undo" << endl;
     return;
   }
 
@@ -2976,7 +2976,7 @@ void polyView::undo() {
 void polyView::redo() {
 
   if (m_posInUndoStack + 1 >= (int)m_polyVecStack.size()) {
-    cout << "No actions to redo" << endl;
+    cout << " No actions to redo" << endl;
     return;
   }
 
@@ -3170,7 +3170,7 @@ void polyView::saveOnePoly() {
   }
 
   poly.writePoly(fileName);
-  cout << "Polygons saved to " << fileName << endl;
+  cout << " Polygons saved to " << fileName << endl;
 
   return;
 }
@@ -3205,7 +3205,7 @@ void polyView::writeMultiplePolys(bool overwrite) {
   }
 
   if ((int)m_polyVec.size() > 0) {
-    cout << "Polygons saved to" << allFiles << endl;
+    cout << " Polygons saved to" << allFiles << endl;
   }
 
   return;
@@ -3341,7 +3341,7 @@ void polyView::printCmd(std::string cmd, const std::vector<double> & vals) {
   }
   S << endl;
 
-  cout << S.str();
+  cout <<" "<< S.str();
 
   return;
 }
@@ -3353,7 +3353,7 @@ void polyView::printCmd(std::string cmd, double xll, double yll,
   int prec = 16;
   S.precision(prec);
   S << cmd << ' ' << xll << ' ' << yll << ' ' << widX << ' ' << widY << endl;
-  cout << S.str();
+  cout <<" "<< S.str();
 
   return;
 }
@@ -3364,7 +3364,7 @@ void polyView::printCmd(std::string cmd) {
   int prec = 16;
   S.precision(prec);
   S << cmd << endl;
-  cout << S.str();
+  cout <<" "<< S.str();
 
   return;
 }
@@ -3507,7 +3507,7 @@ double polyView::calcGrid(double widx, double widy) {
   double grid = max(widx, widy)/50;
 
   if (grid <= 0) {
-    cout << "Warning: non-positive width and height" << endl;
+    cout << " Warning: non-positive width and height" << endl;
     return 1.0;
   }
 

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -461,6 +461,7 @@ void polyView::imageToScreenRect(// inputs
 // from world to screen coordinates.
 void polyView::displayData(QPainter *paint) {
 
+  //utils::Timer my_clock("polyView::displayData");
   setupViewingWindow(); // Must happen before anything else
 
   // This vector is used for sparsing out text on screen
@@ -586,8 +587,9 @@ void polyView::plotDPoly(bool plotPoints, bool plotEdges,
                          // An empty grid is a good choice if not text is present
                          std::vector< std::vector<int> > & textOnScreenGrid,
                          QPainter *paint,
-                         dPoly currPoly) { // Make a local copy on purpose
+                         dPoly &currPoly) { // Make a local copy on purpose
 
+  //utils::Timer my_clock("polyView::plotDPoly");
   // Note: Having annotations at vertices can make the display
   // slow for large polygons.
   // The operations below must happen before cutting,
@@ -627,6 +629,7 @@ void polyView::plotDPoly(bool plotPoints, bool plotEdges,
                     // output
                     clippedPoly);
 
+  //utils::Timer my_clock2("polyView::Paint");
   const double * xv               = clippedPoly.get_xv();
   const double * yv               = clippedPoly.get_yv();
   const int    * numVerts         = clippedPoly.get_numVerts();
@@ -2008,8 +2011,6 @@ void polyView::createHighlightWithPixelInputs(int pxll, int pyll, int pxur, int 
 void polyView::createHighlightWithRealInputs(double xll, double yll, double xur, double yur) {
 
 
-  //utils::Timer my_clock;
-  //my_clock.tick();
 
   dPoly R;
   bool isPolyClosed = true;
@@ -2022,7 +2023,6 @@ void polyView::createHighlightWithRealInputs(double xll, double yll, double xur,
   markPolysInHlts(m_polyVec, m_highlights, // Inputs
                   m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
 
-  //my_clock.tock("markPolysInHlts");
 
   toggleMovePolys();
   saveDataForUndo(false);

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -86,7 +86,6 @@ polyView::polyView(QWidget *parent, chooseFilesDlg * chooseFiles,
 
   m_resetView       = true;
   m_prevClickExists = false;
-  m_firstPaintEvent = true;
 
   m_showAnnotations    = true;
   m_showVertOrPolyIndexAnno  = 0;
@@ -1479,14 +1478,7 @@ void polyView::refreshPixmap() {
 
 void polyView::paintEvent(QPaintEvent *) {
 
-  if (m_firstPaintEvent) {
-    // This will be called the very first time the display is
-    // initialized. There must be a better way.
-    m_firstPaintEvent = false;
-    refreshPixmap(); // Create m_pixmap which we will use as cache
-  }
-
-  // Note that we draw from the cached pixmap, instead of redrawing
+    // Note that we draw from the cached pixmap, instead of redrawing
   // the image from scratch.
   QStylePainter paint(this);
   paint.drawPixmap(0, 0, m_pixmap);

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -1179,9 +1179,9 @@ void polyView::translateSelectedPolys(std::vector<double> & shiftVec) {
   printCmd("translate_selected", shiftVec);
 
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
-  
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
+
   saveDataForUndo(false);
 
   std::cout << "Resetting the view after the translation was applied." << std::endl;
@@ -1235,8 +1235,9 @@ void polyView::rotateSelectedPolys(std::vector<double> & angle) {
   printCmd("rotate_selected", angle);
 
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
+
 
   saveDataForUndo(false);
 
@@ -1289,8 +1290,9 @@ void polyView::scaleSelectedPolys(std::vector<double> & scale) {
   printCmd("scale_selected", scale);
 
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
+
 
   saveDataForUndo(false);
   refreshPixmap();
@@ -1345,8 +1347,9 @@ void polyView::transformSelectedPolys(std::vector<double> & T) {
   printCmd("transform_selected", T);
 
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
+
 
   saveDataForUndo(false);
 
@@ -1371,9 +1374,9 @@ void polyView::reverseSelectedPolys() {
   printCmd("reverse_selected");
 
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
-  
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
+
   saveDataForUndo(false);
 
   refreshPixmap();
@@ -2014,7 +2017,11 @@ void polyView::createHighlightWithRealInputs(double xll, double yll, double xur,
   string color = m_prefs.fgColor, layer = "";
   R.setRectangle(min(xll, xur), min(yll, yur), max(xll, xur), max(yll, yur),
                  isPolyClosed, color, layer);
-  m_highlights.push_back(R);
+
+  // Only keep one highlight, multiple highlights are not really used
+  // and they increase painting time since inside of each highlight is painted separately
+  m_highlights.resize(1);
+  m_highlights[0] = R;
 
   // Flag the polygons and annotations in the highlights
   markPolysInHlts(m_polyVec, m_highlights, // Inputs
@@ -2467,7 +2474,6 @@ void polyView::toggleMovePolys() {
     m_displayMode = m_displayModeBk;
   }    
 
-  refreshPixmap();
   return;
 }
 
@@ -2534,8 +2540,8 @@ void polyView::toggleAlignMode() {
     m_moveEdges->setChecked(false);
 
     m_highlights.clear();
-    markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                    m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+    m_selectedPolyIndices.clear();
+    m_selectedAnnoIndices.clear();
 
     m_totalT.reset();
   }else{
@@ -2808,9 +2814,8 @@ void polyView::moveSelectedPolys() {
 
 void polyView::deselectPolysDeleteHlts() {
   m_highlights.clear();
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
-
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
 
   saveDataForUndo(false);
   refreshPixmap();
@@ -3515,9 +3520,8 @@ void polyView::deleteSelectedPolys() {
                    m_polyVec);
 
   m_highlights.clear();
-
-  markPolysInHlts(m_polyVec, m_highlights, // Inputs
-                  m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+  m_selectedPolyIndices.clear();
+  m_selectedAnnoIndices.clear();
 
   saveDataForUndo(false);
   refreshPixmap();

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -2007,6 +2007,10 @@ void polyView::createHighlightWithPixelInputs(int pxll, int pyll, int pxur, int 
 
 void polyView::createHighlightWithRealInputs(double xll, double yll, double xur, double yur) {
 
+
+  //utils::Timer my_clock;
+  //my_clock.tick();
+
   dPoly R;
   bool isPolyClosed = true;
   string color = m_prefs.fgColor, layer = "";
@@ -2017,6 +2021,8 @@ void polyView::createHighlightWithRealInputs(double xll, double yll, double xur,
   // Flag the polygons and annotations in the highlights
   markPolysInHlts(m_polyVec, m_highlights, // Inputs
                   m_selectedPolyIndices, m_selectedAnnoIndices);  // Outputs
+
+  //my_clock.tock("markPolysInHlts");
 
   toggleMovePolys();
   saveDataForUndo(false);

--- a/gui/polyView.cpp
+++ b/gui/polyView.cpp
@@ -527,11 +527,25 @@ void polyView::displayData(QPainter *paint) {
 
     if (plotPoints) drawVertIndex++;
 
-    bool showAnno = true;
-    plotDPoly(plotPoints, plotEdges, plotFilled, showAnno, lineWidth,
-              drawVertIndex, textOnScreenGrid, paint, m_polyVec[vecIter]);
+    bool has_selected = !plotFilled && !m_selectedPolyIndices[vecIter].empty();
 
-    if (!plotFilled && !m_selectedPolyIndices[vecIter].empty()) {
+    // Mark un-selected polygons and plot un-selected ones before selected ones
+    std::map<int, int> un_selected;
+    if (has_selected){
+    	int Np = m_polyVec[vecIter].get_numPolys();
+    	for (int i = 0; i < Np; i++) {
+    		auto it = m_selectedPolyIndices[vecIter].find(i);
+    		if (it == m_selectedPolyIndices[vecIter].end()) un_selected[i] = 1;
+    	}
+    }
+
+    bool showAnno = true;
+    // Plot all or un-selected ones if there are selected ones
+    plotDPoly(plotPoints, plotEdges, plotFilled, showAnno, lineWidth,
+              drawVertIndex, textOnScreenGrid, paint, m_polyVec[vecIter],
+			  has_selected ? &un_selected : nullptr);
+
+    if (has_selected) {
       // Plot the selected polys on top with thicker lines
 
       int lineWidth2 = 2*lineWidth;

--- a/gui/polyView.h
+++ b/gui/polyView.h
@@ -228,7 +228,7 @@ private:
                  // An empty grid is a good choice if not text is present
                  std::vector<std::vector<int>> & textOnScreenGrid,
                  QPainter *paint,
-                 utils::dPoly currPoly); // Make a local copy on purpose
+                 utils::dPoly &currPoly); // Make a local copy on purpose
 
   void plotImage(QPainter *paint, utils::dPoly const& poly);
 

--- a/gui/polyView.h
+++ b/gui/polyView.h
@@ -228,7 +228,10 @@ private:
                  // An empty grid is a good choice if not text is present
                  std::vector<std::vector<int>> & textOnScreenGrid,
                  QPainter *paint,
-                 utils::dPoly &currPoly); // Make a local copy on purpose
+                 utils::dPoly &currPoly,
+				 // optional input, if provided only clip selected polygons
+				 const std::map<int, int> *selected = nullptr
+				 );
 
   void plotImage(QPainter *paint, utils::dPoly const& poly);
 


### PR DESCRIPTION
Hi Oleg,
I improved performance of viewing large files. On 5 million point polygons, zoom in and out used to take 10 seconds regardless of the zoom area, now it takes 1-2 seconds depending on the zoom area.
I created a tree of bounding boxes of polygons. We need to be careful to clear the tree every-time polygons change. I did my best to do it, please review and see if we need to clear the tree in any other places.
I also added a Timer class to quickly time different parts of the code.
Bayram